### PR TITLE
Fix the bug (GitHub issue #9) with the EEPROM settings storage. The C…

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -74,7 +74,7 @@
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(andrivet)" // Who made the changes.
 #define SHOW_BOOTSCREEN
 #define STRING_SPLASH_LINE1 SHORT_BUILD_VERSION // will be shown during bootup in line 1
 #define STRING_SPLASH_LINE2 WEBSITE_URL         // will be shown during bootup in line 2

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -41,7 +41,7 @@
    * Verbose version identifier which should contain a reference to the location
    * from where the binary was downloaded or the source code was compiled.
    */
-  #define DETAILED_BUILD_VERSION SHORT_BUILD_VERSION " (ADVi3++ 1.0.0)"
+  #define DETAILED_BUILD_VERSION SHORT_BUILD_VERSION " (ADVi3++ 1.0.1)"
 
   /**
    * The STRING_DISTRIBUTION_DATE represents when the binary file was built,
@@ -78,7 +78,7 @@
    * has a distinct Github fork— the Source Code URL should just be the main
    * Marlin repository.
    */
-  #define SOURCE_CODE_URL "https://github.com/andrivet/"
+  #define SOURCE_CODE_URL "https://github.com/andrivet/ADVi3pp-Marlin"
 
   /**
    * Default generic printer UUID.

--- a/Marlin/adv_i3_plus_plus.cpp
+++ b/Marlin/adv_i3_plus_plus.cpp
@@ -36,7 +36,13 @@
 #pragma message "This is a DEBUG build"
 #endif
 
-namespace { const uint16_t advi3_pp_version = 0x0100; } // 1.0.0
+namespace
+{
+    const uint16_t advi3_pp_version = 0x0101;                       // 1.0.1
+    const uint16_t advi3_pp_oldest_lcd_compatible_version = 0x0100; // 1.0.0
+    const uint16_t advi3_pp_newest_lcd_compatible_version = 0x0101; // 1.0.1
+}
+
 namespace { const unsigned long advi3_pp_baudrate = 115200; }
 
 namespace advi3pp {
@@ -75,7 +81,7 @@ void i3PlusPrinter::auto_pid_finished()
 //! @param write Function to use for the actual writing
 //! @param eeprom_index
 //! @param working_crc
-void i3PlusPrinter::store_presets(eeprom_write write, int eeprom_index, uint16_t& working_crc)
+void i3PlusPrinter::store_presets(eeprom_write write, int& eeprom_index, uint16_t& working_crc)
 {
     i3plus.store_presets(write, eeprom_index, working_crc);
 }
@@ -84,7 +90,7 @@ void i3PlusPrinter::store_presets(eeprom_write write, int eeprom_index, uint16_t
 //! @param read Function to use for the actual reading
 //! @param eeprom_index
 //! @param working_crc
-void i3PlusPrinter::restore_presets(eeprom_read read, int eeprom_index, uint16_t& working_crc)
+void i3PlusPrinter::restore_presets(eeprom_read read, int& eeprom_index, uint16_t& working_crc)
 {
     i3plus.restore_presets(read, eeprom_index, working_crc);
 }
@@ -132,7 +138,7 @@ void i3PlusPrinterImpl::task()
 //! @param write Function to use for the actual writing
 //! @param eeprom_index
 //! @param working_crc
-void i3PlusPrinterImpl::store_presets(eeprom_write write, int eeprom_index, uint16_t& working_crc)
+void i3PlusPrinterImpl::store_presets(eeprom_write write, int& eeprom_index, uint16_t& working_crc)
 {
     for(auto& preset: presets_)
     {
@@ -145,7 +151,7 @@ void i3PlusPrinterImpl::store_presets(eeprom_write write, int eeprom_index, uint
 //! @param read Function to use for the actual reading
 //! @param eeprom_index
 //! @param working_crc
-void i3PlusPrinterImpl::restore_presets(eeprom_read read, int eeprom_index, uint16_t& working_crc)
+void i3PlusPrinterImpl::restore_presets(eeprom_read read, int& eeprom_index, uint16_t& working_crc)
 {
     for(auto& preset: presets_)
     {
@@ -992,7 +998,7 @@ void i3PlusPrinterImpl::about(KeyValue key_value)
     adv_i3_pp_lcd_version_ = static_cast<uint16_t>(key_value);
     send_versions();
 
-    if(adv_i3_pp_lcd_version_ != advi3_pp_version)
+    if(adv_i3_pp_lcd_version_ < advi3_pp_oldest_lcd_compatible_version || adv_i3_pp_lcd_version_ > advi3_pp_newest_lcd_compatible_version)
         show_page(Page::Mismatch);
     else
         show_page(Page::About);

--- a/Marlin/adv_i3_plus_plus.h
+++ b/Marlin/adv_i3_plus_plus.h
@@ -74,8 +74,8 @@ struct i3PlusPrinter
     static void task();
     static void update_graph_data();
     static void auto_pid_finished();
-    static void store_presets(eeprom_write write, int eeprom_index, uint16_t& working_crc);
-    static void restore_presets(eeprom_read read, int eeprom_index, uint16_t& working_crc);
+    static void store_presets(eeprom_write write, int& eeprom_index, uint16_t& working_crc);
+    static void restore_presets(eeprom_read read, int& eeprom_index, uint16_t& working_crc);
     static void reset_presets();
     static void temperature_error();
 };

--- a/Marlin/adv_i3_plus_plus_impl.h
+++ b/Marlin/adv_i3_plus_plus_impl.h
@@ -62,8 +62,8 @@ public:
     void show_page(Page page);
     void update_graph_data();
     void auto_pid_finished();
-    void store_presets(eeprom_write write, int eeprom_index, uint16_t& working_crc);
-    void restore_presets(eeprom_read read, int eeprom_index, uint16_t& working_crc);
+    void store_presets(eeprom_write write, int& eeprom_index, uint16_t& working_crc);
+    void restore_presets(eeprom_read read, int& eeprom_index, uint16_t& working_crc);
     void reset_presets();
     void temperature_error();
 


### PR DESCRIPTION
…RC was not correctly computed and thus the reading of settings failed. Raise the mainboard version to 1.0.1 (LCD not changed)